### PR TITLE
Change default API init port to 54235 for Razer Chroma SDK >= 2.2.4

### DIFF
--- a/src/Chroma.NetCore.Api/Chroma/ChromaApp.cs
+++ b/src/Chroma.NetCore.Api/Chroma/ChromaApp.cs
@@ -10,6 +10,9 @@ namespace Chroma.NetCore.Api.Chroma
     public class ChromaApp
     {
         private ChromaInstance instance;
+
+        private const string DEFAULT_BASE_ADDRESS = "http://localhost:54235";
+
         internal string jsonAppDefinition;
 
         public ChromaApp(string jsonAppDefinition)
@@ -46,7 +49,7 @@ namespace Chroma.NetCore.Api.Chroma
             this.jsonAppDefinition = JsonConvert.SerializeObject(appDefinition, Formatting.Indented);
         }
 
-        public async Task<ChromaInstance> Instance(string apiBaseAddress = "http://localhost/")
+        public async Task<ChromaInstance> Instance(string apiBaseAddress = DEFAULT_BASE_ADDRESS)
         {
             if (instance != null)
                 return instance;

--- a/test/Chroma.NetCore.Api.Tests/Chroma/AnimationTests.cs
+++ b/test/Chroma.NetCore.Api.Tests/Chroma/AnimationTests.cs
@@ -12,6 +12,9 @@ namespace Chroma.NetCore.Api.Tests.Chroma
         [Fact]
         public async void TestAnimationCreateFrames()
         {
+            //Set DebugMode to debug with Fiddler
+            //Bootsrapper.DebugMode = true;
+
             var tests = new ChromaInstanceTests();
             var instance = await tests.Instance_ReturnValidInstance();
 

--- a/test/Chroma.NetCore.Api.Tests/ChromaHttpClientTests.cs
+++ b/test/Chroma.NetCore.Api.Tests/ChromaHttpClientTests.cs
@@ -12,11 +12,13 @@ namespace Chroma.NetCore.Api.Tests
     {
         private readonly string testFilePath;
 
+        private const int API_PORT = 54235;
+
         private readonly ClientConfiguration clientConfiguration;
 
         private ChromaHttpClient chromaHttpClient;
 
-        private readonly Uri baseUri = new Uri(Bootsrapper.DebugMode ? "http://localhost.fiddler/" : "http://localhost/");
+        private readonly Uri baseUri = new Uri(Bootsrapper.DebugMode ? $"http://localhost.fiddler:{API_PORT}/" : $"http://localhost:{API_PORT}/");
 
         public ChromaHttpClientTests()
         {


### PR DESCRIPTION
With Chroma SDK 2.2.4 default port to init the API has changed to 54235